### PR TITLE
Fix Docker startup instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## Basic Startup
 ```
-docker run --name <container-name> -d ghcr.io/ChainGreenOrg/chaingreen:latest
+docker run --name <container-name> -d ghcr.io/chaingreenorg/chaingreen:latest
 (optional -v /path/to/plots:/plots)
 ```
 #### set the timezone for the container (optional, defaults to UTC)


### PR DESCRIPTION
Fix the name of the repository for the Docker image in the instructions to be with lowercase letters.